### PR TITLE
Adds functions for passing pattern eg ( :QFGrepV "pattern" )

### DIFF
--- a/plugin/QFGrep.vim
+++ b/plugin/QFGrep.vim
@@ -57,9 +57,8 @@ endif
 "the message header
 let s:msgHead = '[QFGrep] ' 
 
-
-"do grep on quickfix entries
-function! <SID>GrepQuickFix(invert)
+"helpers
+function! <SID>SaveQuickFix() 
   "store original quickfix lists, so that later could be restored
   let s:origQF = len( s:origQF )>0? s:origQF : getqflist()
   let all = getqflist()
@@ -67,7 +66,44 @@ function! <SID>GrepQuickFix(invert)
     call PrintErrMsg('Quickfix window is empty. Nothing could be grepped. ')
     return
   endif
-  let cp = deepcopy(all)
+
+  return deepcopy(all)
+endfunction
+
+function! <SID>DoFilter(pat, invert, cp) 
+  exec 'redraw' 
+  if empty(a:pat)
+    call PrintErrMsg("Empty pattern is not allowed")
+    return
+  endif
+  try
+    for d in a:cp
+      if (!a:invert)
+        if ( bufname(d['bufnr']) !~ a:pat && d['text'] !~ a:pat)
+          call remove(a:cp, index(a:cp,d))
+        endif
+      else " here do invert matching
+        if (bufname(d['bufnr']) =~ a:pat || d['text'] =~ a:pat)
+          call remove(a:cp, index(a:cp,d))
+        endif
+      endif
+    endfor
+    if empty(a:cp)
+      call PrintErrMsg('Empty resultset, aborted.')
+    else		"found entries
+      call setqflist(a:cp)
+      call PrintHLInfo(len(a:cp) . ' entries in Grep result.')
+    endif
+  catch /^Vim\%((\a\+)\)\=:E/
+    call PrintErrMsg('Pattern invalid')
+  endtry
+endfunction
+
+
+"do grep on quickfix entries
+function! <SID>GrepQuickFix(invert)
+  let cp = <SID>SaveQuickFix()
+
   call inputsave()
   echohl QFGPrompt
   let pat = input( s:msgHead . 'Pattern' . (a:invert?' (Invert-matching):':':'))
@@ -79,28 +115,16 @@ function! <SID>GrepQuickFix(invert)
     call PrintErrMsg("Empty pattern is not allowed")
     return
   endif
-  try
-    for d in cp
-      if (!a:invert)
-        if ( bufname(d['bufnr']) !~ pat && d['text'] !~ pat)
-          call remove(cp, index(cp,d))
-        endif
-      else " here do invert matching
-        if (bufname(d['bufnr']) =~ pat || d['text'] =~ pat)
-          call remove(cp, index(cp,d))
-        endif
-      endif
-    endfor
-    if empty(cp)
-      call PrintErrMsg('Empty resultset, aborted.')
-    else		"found entries
-      call setqflist(cp)
-      call PrintHLInfo(len(cp) . ' entries in Grep result.')
-    endif
-  catch /^Vim\%((\a\+)\)\=:E/
-    call PrintErrMsg('Pattern invalid')
-  endtry
 
+  call <SID>DoFilter( pat, a:invert, cp )
+
+endfunction
+
+"do grep on quickfix without prompting for pattern
+function! <SID>FilterQuickFixWithPattern( pat, invert )
+  let cp = <SID>SaveQuickFix()
+
+  call <SID>DoFilter( a:pat, a:invert, cp )
 endfunction
 
 
@@ -135,9 +159,11 @@ fun! <SID>FTautocmdBatch()
   execute 'hi QFGPrompt ' . g:QFG_hi_prompt
   execute 'hi QFGInfo '   . g:QFG_hi_info
   execute 'hi QFGError '  . g:QFG_hi_error
-  command! QFGrep    call <SID>GrepQuickFix(0)  "invert flag =0
-  command! QFGrepV   call <SID>GrepQuickFix(1)  "invert flag =1
-  command! QFRestore call <SID>RestoreQuickFix()
+  command! -nargs=0 QFGrep     call <SID>GrepQuickFix(0)                        "invert flag =0
+  command! -nargs=0 QFGrepV    call <SID>GrepQuickFix(1)                        "invert flag =1
+  command! -nargs=0 QFRestore  call <SID>RestoreQuickFix()
+  command! -nargs=1 QFGrepPat  call <SID>FilterQuickFixWithPattern("<args>",0)  "invert flag =0
+  command! -nargs=1 QFGrepPatV call <SID>FilterQuickFixWithPattern("<args>",1)  "invert flag =1
   "mapping
   execute 'nnoremap <buffer><silent>' . g:QFG_Grep    . ' :QFGrep<cr>'
   execute 'nnoremap <buffer><silent>' . g:QFG_GrepV   . ' :QFGrepV<cr>'


### PR DESCRIPTION
add function which is passed the pattern as a parameter rather than prompting

add commands QFGrepPat and QFGrepPatV to access this function
split out code for saving quickfix and filtering quickfix into separate functions to be called by both grep functions
