### PR TITLE
Avoid delay with mapping for :QFGrep

### DIFF
--- a/doc/QFGrep.txt
+++ b/doc/QFGrep.txt
@@ -71,10 +71,10 @@ CONFIGURATION                                            *QFGrep-configuration*
 There are three `<Plug>` mappings in QFGrep, to let user easily create
 customized mapping
 
-<Plug>QFGrep
+<Plug>QFGrepG
     mapping for |:QFGrep| command. E.g >
 
-    nmap <buffer> {Mykeys} <Plug>QFGrep
+    nmap <buffer> {Mykeys} <Plug>QFGrepG
 <
     Default mapping: <Leader>g
 

--- a/plugin/QFGrep.vim
+++ b/plugin/QFGrep.vim
@@ -30,7 +30,7 @@ command! QFGrepVersion echo "QFGrep Version: " . s:version
 
 
 "mappings
-nnoremap <silent><unique> <Plug>QFGrep :call QFGrep#grep_QuickFix(0)<cr>
+nnoremap <silent><unique> <Plug>QFGrepG :call QFGrep#grep_QuickFix(0)<cr>
 nnoremap <silent><unique> <Plug>QFGrepV :call QFGrep#grep_QuickFix(1)<cr>
 nnoremap <silent><unique> <Plug>QFRestore :call QFGrep#restore_QuickFix()<cr>
 
@@ -44,8 +44,8 @@ function! <SID>FTautocmdBatch()
   command! -nargs=1 QFGrepPatV call QFGrep#grep_QuickFix_with_pattern("<args>",1)  "invert flag =1
 
   "create mapping
-  if !hasmapto('<Plug>QFGrep','n')
-    nmap <buffer> <Leader>g <Plug>QFGrep
+  if !hasmapto('<Plug>QFGrepG','n')
+    nmap <buffer> <Leader>g <Plug>QFGrepG
   endif
   if !hasmapto('<Plug>QFGrepV','n')
     nmap <buffer> <Leader>v <Plug>QFGrepV


### PR DESCRIPTION
First of all, thank you very much for sharing this plugin, it is a great idea to grep the quickifix window.

I've noticed that when the mapping for `:QFGrep` is entered there is a delay for triggering the command. Typing any other character after the mapping, as a space, removes the delay. 

This probably happens because vim is waiting to check if the user will enter additional keys, as there is more than one mapping matching those keys. In this case, it is waiting to choose `<Plug>QFGrep` or `<Plug>QFGrepV`. With the default mappings, `<leader>g` triggers `:QFGrep`, while  `<leader>gV` triggers `:QFGrepV`.

Changing `<Plug>QFGrep` to `<Plug>QFGrepG` removes the delay.
