### PR TITLE
consider the whole line instead of filename/text

### DIFF
--- a/autoload/QFGrep.vim
+++ b/autoload/QFGrep.vim
@@ -99,12 +99,13 @@ function! QFGrep#do_grep(pat, invert, cp)
 
   try
     for d in a:cp
+      let line = bufname(d.bufnr).'|'.d.lnum.'| '.d.text
       if (!a:invert)
-        if ( bufname(d['bufnr']) !~ a:pat && d['text'] !~ a:pat)
+        if (line !~ a:pat)
           call remove(a:cp, index(a:cp,d))
         endif
       else " here do invert matching
-        if (bufname(d['bufnr']) =~ a:pat || d['text'] =~ a:pat)
+        if (line =~ a:pat)
           call remove(a:cp, index(a:cp,d))
         endif
       endif


### PR DESCRIPTION
Sometimes I find useful to filter the quickfix contents based only on the filename instead of the text.
For example, if the quickfix window contains the following lines:

```
/path/x/fileA.cpp|50| <<global>> #include "fileY.h"
/path/x/fileB.h|50| <<global>> #include "fileY.h"
/path/x/fileC.cpp|50| <<global>> #include "fileY.h"
```

If I want only the .h files that contains a given pattern I could try `:QFGrep \.h|`.

But currently this doesn't work because the matching is done against the filename and the text.
I think most users will think they are grepping the lines displayed on the quickfix, so the current form may be a little misleading.
