### PR TITLE
Include handling for location list

### DIFF
--- a/plugin/QFGrep.vim
+++ b/plugin/QFGrep.vim
@@ -58,8 +58,6 @@ endfunction
 
 augroup QFG
   au!
-  autocmd QuickFixCmdPre * call QFGrep#init_origQF()
-  autocmd QuickFixCmdPost * call QFGrep#fill_origQF()
   autocmd FileType qf call <SID>FTautocmdBatch()
 augroup end
 


### PR DESCRIPTION
It seems to me that the most complex change to work with both quickfix and location lists is the restore action: QFGrep must store the original contents of quickfix and of each location list.

The existing approach of using `QuickFixCmdPre` and `QuickFixCmdPost` isn't suitable for location lists, as it is hard to tell which location list is going to be updated for a given command (e.g.: `lgrep`).
An additional advantage of the approach below is that the autoload section will be loaded only if the plugin is actually used, instead of upon `QuickFixCmdPre`.