### PR TITLE
trigger QuickFixCmdPost qfgrep/lqfgrep

### DIFF
--- a/autoload/QFGrep.vim
+++ b/autoload/QFGrep.vim
@@ -105,9 +105,11 @@ function! QFGrep#set_list(list)
   if QFGrep#is_loc_list()
     call setloclist(0, a:list)
     let b:lastLL = a:list
+    silent doautocmd QuickFixCmdPost lqfgrep
   else
     call setqflist(a:list)
     let s:lastQF = a:list
+    silent doautocmd QuickFixCmdPost qfgrep
   endif
 endfunction
 

--- a/doc/QFGrep.txt
+++ b/doc/QFGrep.txt
@@ -43,6 +43,9 @@ USAGE                                                            *QFGrep-usage*
 
 The above mapping could be customized. see |QFGrep-mapping|
 
+The QuickFixCmdPost autocommand fires with pattern qfgrep (or lqfgrep) after a
+successful operation and can be used for advanced customization.
+
                                   *:QFGrepV* *:QFRestore* *:QFGrep* *QFGrep-commands*
 |QFGrep| has following commands:
 

--- a/plugin/QFGrep.vim
+++ b/plugin/QFGrep.vim
@@ -58,8 +58,6 @@ endfunction
 
 augroup QFG
   au!
-  autocmd QuickFixCmdPre * call QFGrep#init_origQF()
-  autocmd QuickFixCmdPost * call QFGrep#fill_origQF()
   autocmd FileType qf call <SID>FTautocmdBatch()
 augroup end
 


### PR DESCRIPTION
It is possible to perform customizations when the quickfix and location list are updated through several commands, such as `:grep` and `:lgrep`. This changes allows to also detect the changes made by this plugin.